### PR TITLE
Use relative link to the status page

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ Update: Hey, guys, we're still moving along we will be providing an SDK that is 
 
 We are looking for supporters/coders that can help bring about faster Development of PureDarwin while showing Apple that there is still a community of Open Source Darwin Supporters that would like to see more openness from them whether it be from them releasing Binary Drivers for our use as they once did or open source projects like libxpc/launchd again.
 
-[PureDarwin's Current Build Status](https://puredarwin.github.io/Status.md)
+[PureDarwin's Current Build Status](Status.md)
 
 ### PureDarwin IRC Channel!
 Please join us on freenode.net #puredarwin for our info we have USA/UK/Europe Devs who which can receive hardware.


### PR DESCRIPTION
Otherwise Github will first redirect us and then wants us to download a page from http://puredarwin.github.io/Status.md with

     Content-Type: text/markdown

We should use https://github.blog/2013-01-31-relative-links-in-markup-files/ automagic facility to rewrite .md links into .html ones for us.